### PR TITLE
Add TessaController as a service

### DIFF
--- a/Eikona/Tessa/ConnectorBundle/Resources/config/controllers.yml
+++ b/Eikona/Tessa/ConnectorBundle/Resources/config/controllers.yml
@@ -15,3 +15,9 @@ services:
     public: true
     arguments:
       - '@doctrine.orm.entity_manager'
+  
+  eikona.tessa.controller.tessa:
+    class: Eikona\Tessa\ConnectorBundle\Controller\TessaController
+    public: true
+    arguments:
+      - '@eikona.tessa'


### PR DESCRIPTION
This controller is not callable when we go to /tessa path because it is not referenced as a service